### PR TITLE
Revert to common 4.2

### DIFF
--- a/bionic/debian/control
+++ b/bionic/debian/control
@@ -5,7 +5,7 @@ Section: science
 Priority: optional
 Build-Depends: debhelper (>= 11),
                libignition-cmake2-dev (>= 2.8.0),
-               libignition-common4-dev (>= 4.3.0),
+               libignition-common4-dev (>= 4.2.0),
                libignition-fuel-tools7-dev,
                libignition-gazebo6-dev,
                libignition-gui6-dev,
@@ -30,7 +30,7 @@ Package: ignition-fortress
 Architecture: any
 Section: libdevel
 Depends: libignition-cmake2-dev (>= 2.7.0),
-         libignition-common4-dev (>= 4.3.0),
+         libignition-common4-dev (>= 4.2.0),
          libignition-fuel-tools7-dev,
          libignition-gazebo6-dev,
          libignition-gui6-dev,

--- a/debian/buster/debian/control
+++ b/debian/buster/debian/control
@@ -5,7 +5,7 @@ Section: science
 Priority: optional
 Build-Depends: debhelper (>= 11),
                libignition-cmake2-dev (>= 2.8.0),
-               libignition-common4-dev (>= 4.3.0),
+               libignition-common4-dev (>= 4.2.0),
                libignition-fuel-tools7-dev,
                libignition-gazebo6-dev,
                libignition-gui6-dev,
@@ -30,7 +30,7 @@ Package: ignition-fortress
 Architecture: any
 Section: libdevel
 Depends: libignition-cmake2-dev (>= 2.7.0),
-         libignition-common4-dev (>= 4.3.0),
+         libignition-common4-dev (>= 4.2.0),
          libignition-fuel-tools7-dev,
          libignition-gazebo6-dev,
          libignition-gui6-dev,

--- a/focal/debian/control
+++ b/focal/debian/control
@@ -5,7 +5,7 @@ Section: science
 Priority: optional
 Build-Depends: debhelper (>= 11),
                libignition-cmake2-dev (>= 2.8.0),
-               libignition-common4-dev (>= 4.3.0),
+               libignition-common4-dev (>= 4.2.0),
                libignition-fuel-tools7-dev,
                libignition-gazebo6-dev,
                libignition-gui6-dev,
@@ -30,7 +30,7 @@ Package: ignition-fortress
 Architecture: any
 Section: libdevel
 Depends: libignition-cmake2-dev (>= 2.7.0),
-         libignition-common4-dev (>= 4.3.0),
+         libignition-common4-dev (>= 4.2.0),
          libignition-fuel-tools7-dev,
          libignition-gazebo6-dev,
          libignition-gui6-dev,

--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -5,7 +5,7 @@ Section: science
 Priority: optional
 Build-Depends: debhelper (>= 11),
                libignition-cmake2-dev (>= 2.8.0),
-               libignition-common4-dev (>= 4.3.0),
+               libignition-common4-dev (>= 4.2.0),
                libignition-fuel-tools7-dev,
                libignition-gazebo6-dev,
                libignition-gui6-dev,
@@ -30,7 +30,7 @@ Package: ignition-fortress
 Architecture: any
 Section: libdevel
 Depends: libignition-cmake2-dev (>= 2.7.0),
-         libignition-common4-dev (>= 4.3.0),
+         libignition-common4-dev (>= 4.2.0),
          libignition-fuel-tools7-dev,
          libignition-gazebo6-dev,
          libignition-gui6-dev,


### PR DESCRIPTION
Similar problem to https://github.com/ignition-release/ign-gazebo6-release/pull/4:

```
Correcting dependencies...Starting pkgProblemResolver with broken count: 1
Starting 2 pkgProblemResolver with broken count: 1
Investigating (0) ignition-fortress-build-deps:amd64 < 1.0.0~pre1-1~focal @iU mK Nb Ib >
Broken ignition-fortress-build-deps:amd64 Depends on libignition-common4-dev:amd64 < none -> 4.3.0~pre1-1~focal @un uN > (>= 4.3.0)
  Removing ignition-fortress-build-deps:amd64 because I can't find libignition-common4-dev:amd64
```

Reverting for now, need to investigate what's up